### PR TITLE
feat: modify migrations to delete associate datas

### DIFF
--- a/migrations/20190115071422-create-like.js
+++ b/migrations/20190115071422-create-like.js
@@ -12,7 +12,12 @@ module.exports = {
         type: Sequelize.INTEGER
       },
       TweetId: {
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'Tweets',
+          key: 'id'
+        },
+        onDelete: 'CASCADE'
       },
       createdAt: {
         allowNull: false,

--- a/migrations/20190115071422-create-reply.js
+++ b/migrations/20190115071422-create-reply.js
@@ -12,7 +12,12 @@ module.exports = {
         type: Sequelize.INTEGER
       },
       TweetId: {
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'Tweets',
+          key: 'id'
+        },
+        onDelete: 'CASCADE'
       },
       comment: {
         type: Sequelize.TEXT

--- a/models/tweet.js
+++ b/models/tweet.js
@@ -6,8 +6,14 @@ module.exports = (sequelize, DataTypes) => {
   class Tweet extends Model {
     static associate (models) {
       Tweet.belongsTo(models.User, { foreignKey: 'UserId' })
-      Tweet.hasMany(models.Reply, { foreignKey: 'TweetId' })
-      Tweet.hasMany(models.Like, { foreignKey: 'TweetId' })
+      Tweet.hasMany(models.Reply, {
+        foreignKey: 'TweetId',
+        onDelete: 'CASCADE'
+      })
+      Tweet.hasMany(models.Like, {
+        foreignKey: 'TweetId',
+        onDelete: 'CASCADE'
+      })
     }
   }
   Tweet.init({


### PR DESCRIPTION
1. 當刪除推文時，也可以成功刪除關聯的留言以及按讚資料
2. 由於在 reply & like 的 migration 裡面使用 references 來指定 tweet 資料庫，所以必須調整 migration 載入順序